### PR TITLE
help on singout page - as per live service, changed because we worried…

### DIFF
--- a/app/views/private-beta-17/signed_out.html
+++ b/app/views/private-beta-17/signed_out.html
@@ -1,24 +1,27 @@
 {% extends "./layout/layout.html" %}
 
-{% block title %}Logout{% endblock %}
+{% block title %}Signed out{% endblock %}
 
 {% block body %}
-  <h1 class="heading-large">Signed out</h1>
+  
   <div class="grid-row">
     <div class="column-two-thirds">
       <!-- <p>PatSmith</p> -->
+      <h1 class="heading-large">Signed out</h1>
       <p>You have now signed out.</p>
       <p>If you need a different service you can <a href="{{path}}">return to the start page</a>.</p>
 
       <h2 class="heading-medium collapse-top">What did you think of this service?</h2>
         <p><a href="mailto:digital-register-feedback@digital.landregistry.gov.uk">Please give us your feedback</a> (takes 30 seconds). <br>This is a new service and your feedback will help us improve it.</p>
 
-<!--       <div class="text spacing-top-double">
-        <div class="panel panel-border-narrow spacing-top-single">
-          <p>If you have any queries, you can contact HM Land Registry using the <a href="http://landregistry.custhelp.com/app/contactus_general/">general enquiry contact form</a> or call <a class="bold" href="tel:+443000060411">0300 006 0411</a>.</p>
-          <p>If you need to speak to someone in Welsh call <a class="bold" href="tel:+443000060422">0300 006 0422</a>.</p>
-        </div>
-      </div> -->
+    </div>
+    <div class="column-one-third tablet-column-one-third spacing-top-single">
+      <aside class="supplementary-panel">
+        <h2 class="heading-medium">Help using this service</h2>
+        <p>If you need help using the service you can call Land Registry on 0300 006 0411.</p>
+        <p>If you need to speak to someone in Welsh call 0300 006 0422.</p>
+
+      </aside>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
… PA error accounts need onward journey to make people sign out, so add text on signed out page - for if they need/want to call us.  Yuk!  Don't think this will work well for that scenario. And all other signed out scenarios now sub-optimal?